### PR TITLE
Bump kustomize to 4.5.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(HACK_BIN)/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	env GOBIN=$(HACK_BIN) go install sigs.k8s.io/kustomize/kustomize/v3@v3.8.7
+	env GOBIN=$(HACK_BIN) go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
 
 ENVTEST = $(HACK_BIN)/setup-envtest
 .PHONY: envtest


### PR DESCRIPTION
We had issues running `make install`. Kustomize threw this error:
```
$ make install
...
/home/user/workspace/cluster-api-ipam-provider-in-cluster/hack/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases                                                    env GOBIN=/home/kokoni/workspace/cluster-api-ipam-provider-in-cluster/hack/bin go install sigs.k8s.io/kustomize/kustomize/v3@v3.8.7
go: sigs.k8s.io/kustomize/kustomize/v3@v3.8.7 (in sigs.k8s.io/kustomize/kustomize/v3@v3.8.7):                                                                                                                                                    The go.mod file for the module providing named packages contains one or                                                                                                                                                                  more exclude directives. It must not contain directives that would cause                                                                                                                                                                 it to be interpreted differently than if it were the main module.
make: *** [Makefile:113: kustomize] Error 1
```

Bumping to 4.5.7 remedied the error and we were able to then successfully run `make install deploy`