### PR TITLE
replace inet.af/netaddr with net/netip and netipx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.8.4
 	github.com/onsi/gomega v1.27.2
 	github.com/pkg/errors v0.9.1
-	inet.af/netaddr v0.0.0-20220811202034-502d2d690317
+	go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35
 	k8s.io/api v0.25.6
 	k8s.io/apimachinery v0.25.7
 	k8s.io/client-go v0.25.6
@@ -65,8 +65,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	go4.org/intern v0.0.0-20220617035311-6925f38cc365 // indirect
-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,7 +97,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
 github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -361,12 +360,8 @@ go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95a
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
-go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
-go4.org/intern v0.0.0-20220617035311-6925f38cc365 h1:t9hFvR102YlOqU0fQn1wgwhNvSbHGBbbJxX9JKfU3l0=
-go4.org/intern v0.0.0-20220617035311-6925f38cc365/go.mod h1:WXRv3p7T6gzt0CcJm43AAKdKVZmcQbwwC7EwquU5BZU=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35 h1:nJAwRlGWZZDOD+6wni9KVUNHMpHko/OnRwsrCYeAzPo=
+go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35/go.mod h1:TQvodOM+hJTioNQJilmLXu08JNb8i+ccq418+KWu1/Y=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -497,7 +492,6 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -571,7 +565,6 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -698,8 +691,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-inet.af/netaddr v0.0.0-20220811202034-502d2d690317 h1:U2fwK6P2EqmopP/hFLTOAjWTki0qgd4GMJn5X8wOleU=
-inet.af/netaddr v0.0.0-20220811202034-502d2d690317/go.mod h1:OIezDfdzOgFhuw4HuWapWq2e9l0H9tK4F1j+ETRtF3k=
 k8s.io/api v0.25.6 h1:LwDY2H6kD/3R8TekJYYaJWOdekNdXDO44eVpX6sNtJA=
 k8s.io/api v0.25.6/go.mod h1:bVp01KUcl8VUHFBTJMOknWNo7XvR0cMbeTTuFg1zCUs=
 k8s.io/apiextensions-apiserver v0.25.4 h1:7hu9pF+xikxQuQZ7/30z/qxIPZc2J1lFElPtr7f+B6U=

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -18,14 +18,10 @@ const (
 
 // SetupIndexes adds indexes to the cache of a Manager.
 func SetupIndexes(ctx context.Context, mgr manager.Manager) error {
-	if err := mgr.GetCache().IndexField(ctx, &ipamv1.IPAddress{},
+	return mgr.GetCache().IndexField(ctx, &ipamv1.IPAddress{},
 		IPAddressPoolRefCombinedField,
 		ipAddressByCombinedPoolRef,
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
 func ipAddressByCombinedPoolRef(o client.Object) []string {

--- a/internal/poolutil/pool_test.go
+++ b/internal/poolutil/pool_test.go
@@ -1,9 +1,11 @@
 package poolutil
 
 import (
+	"net/netip"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"inet.af/netaddr"
+	"go4.org/netipx"
 
 	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
 )
@@ -18,47 +20,47 @@ var _ = Describe("AddressListToSet", func() {
 		ipSet, err := AddressesToIPSet(addressSlice)
 		Expect(err).NotTo(HaveOccurred())
 
-		ip, err := netaddr.ParseIP("192.168.1.25")
+		ip, err := netip.ParseAddr("192.168.1.25")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeTrue())
 
-		ip, err = netaddr.ParseIP("192.168.1.26")
+		ip, err = netip.ParseAddr("192.168.1.26")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeTrue())
 
-		ip, err = netaddr.ParseIP("192.168.1.27")
+		ip, err = netip.ParseAddr("192.168.1.27")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeTrue())
 
-		ip, err = netaddr.ParseIP("192.168.1.28")
+		ip, err = netip.ParseAddr("192.168.1.28")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeTrue())
 
-		ip, err = netaddr.ParseIP("192.168.1.29")
+		ip, err = netip.ParseAddr("192.168.1.29")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeFalse())
 
-		ip, err = netaddr.ParseIP("192.168.2.15")
+		ip, err = netip.ParseAddr("192.168.2.15")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeFalse())
 
-		ip, err = netaddr.ParseIP("192.168.2.16")
+		ip, err = netip.ParseAddr("192.168.2.16")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeTrue())
 
-		ip, err = netaddr.ParseIP("192.168.2.17")
+		ip, err = netip.ParseAddr("192.168.2.17")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeTrue())
 
-		ip, err = netaddr.ParseIP("192.168.2.18")
+		ip, err = netip.ParseAddr("192.168.2.18")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeTrue())
 
-		ip, err = netaddr.ParseIP("192.168.2.19")
+		ip, err = netip.ParseAddr("192.168.2.19")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeTrue())
 
-		ip, err = netaddr.ParseIP("192.168.2.20")
+		ip, err = netip.ParseAddr("192.168.2.20")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipSet.Contains(ip)).To(BeFalse())
 	})
@@ -75,8 +77,8 @@ var _ = Describe("AddressListToSet", func() {
 
 var _ = Describe("FindFreeAddress", func() {
 	var (
-		freeIPSet *netaddr.IPSet
-		existing  *netaddr.IPSet
+		freeIPSet *netipx.IPSet
+		existing  *netipx.IPSet
 	)
 
 	type iprange struct {
@@ -84,16 +86,16 @@ var _ = Describe("FindFreeAddress", func() {
 		To   string
 	}
 
-	createIPSet := func(ipranges []iprange) *netaddr.IPSet {
-		builder := netaddr.IPSetBuilder{}
+	createIPSet := func(ipranges []iprange) *netipx.IPSet {
+		builder := netipx.IPSetBuilder{}
 		for _, r := range ipranges {
-			first, err := netaddr.ParseIP(r.From)
+			first, err := netip.ParseAddr(r.From)
 			Expect(err).NotTo(HaveOccurred())
 
-			second, err := netaddr.ParseIP(r.To)
+			second, err := netip.ParseAddr(r.To)
 			Expect(err).NotTo(HaveOccurred())
 
-			builder.AddRange(netaddr.IPRangeFrom(first, second))
+			builder.AddRange(netipx.IPRangeFrom(first, second))
 		}
 
 		ipSet, err := builder.IPSet()
@@ -106,7 +108,7 @@ var _ = Describe("FindFreeAddress", func() {
 		freeIPSet = nil
 
 		var err error
-		existingIPSetBuilder := netaddr.IPSetBuilder{}
+		existingIPSetBuilder := netipx.IPSetBuilder{}
 		existing, err = existingIPSetBuilder.IPSet()
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -406,8 +408,8 @@ var _ = Describe("IPPoolSpecToIPSet", func() {
 	})
 })
 
-func mustParse(ipString string) netaddr.IP {
-	ip, err := netaddr.ParseIP(ipString)
+func mustParse(ipString string) netip.Addr {
+	ip, err := netip.ParseAddr(ipString)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return ip
 }

--- a/internal/webhooks/inclusterippool.go
+++ b/internal/webhooks/inclusterippool.go
@@ -37,7 +37,7 @@ var _ webhook.CustomDefaulter = &InClusterIPPool{}
 var _ webhook.CustomValidator = &InClusterIPPool{}
 
 // Default satisfies the defaulting webhook interface.
-func (webhook *InClusterIPPool) Default(ctx context.Context, obj runtime.Object) error {
+func (webhook *InClusterIPPool) Default(_ context.Context, obj runtime.Object) error {
 	pool, ok := obj.(*v1alpha1.InClusterIPPool)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a InClusterIPPool but got a %T", obj))
@@ -79,7 +79,7 @@ func (webhook *InClusterIPPool) Default(ctx context.Context, obj runtime.Object)
 			pool.Spec.Last = prefixRange.To().Prev().String() // omits the last address, the assumed broadcast
 		}
 		if pool.Spec.Prefix == 0 {
-			pool.Spec.Prefix = int(prefix.Bits())
+			pool.Spec.Prefix = prefix.Bits()
 		}
 	}
 
@@ -87,7 +87,7 @@ func (webhook *InClusterIPPool) Default(ctx context.Context, obj runtime.Object)
 }
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (webhook *InClusterIPPool) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+func (webhook *InClusterIPPool) ValidateCreate(_ context.Context, obj runtime.Object) error {
 	pool, ok := obj.(*v1alpha1.InClusterIPPool)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a InClusterIPPool but got a %T", obj))
@@ -96,7 +96,7 @@ func (webhook *InClusterIPPool) ValidateCreate(ctx context.Context, obj runtime.
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (webhook *InClusterIPPool) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+func (webhook *InClusterIPPool) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
 	newPool, ok := newObj.(*v1alpha1.InClusterIPPool)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a InClusterIPPool but got a %T", newObj))
@@ -109,7 +109,7 @@ func (webhook *InClusterIPPool) ValidateUpdate(ctx context.Context, oldObj, newO
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
-func (webhook *InClusterIPPool) ValidateDelete(_ context.Context, obj runtime.Object) (reterr error) {
+func (webhook *InClusterIPPool) ValidateDelete(_ context.Context, _ runtime.Object) (reterr error) {
 	return nil
 }
 

--- a/internal/webhooks/inclusterippool.go
+++ b/internal/webhooks/inclusterippool.go
@@ -3,8 +3,9 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
-	"inet.af/netaddr"
+	"go4.org/netipx"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -47,14 +48,14 @@ func (webhook *InClusterIPPool) Default(ctx context.Context, obj runtime.Object)
 	}
 
 	if pool.Spec.Subnet == "" {
-		first, err := netaddr.ParseIP(pool.Spec.First)
+		first, err := netip.ParseAddr(pool.Spec.First)
 		if err != nil {
 			return apierrors.NewInvalid(v1alpha1.GroupVersion.WithKind("InClusterIPPool").GroupKind(), pool.Name, field.ErrorList{
 				field.Invalid(field.NewPath("spec", "subnet"), pool.Spec.Subnet, err.Error()),
 			})
 		}
 
-		prefix, err := first.Prefix(uint8(pool.Spec.Prefix))
+		prefix, err := first.Prefix(pool.Spec.Prefix)
 		if err != nil {
 			return apierrors.NewInvalid(v1alpha1.GroupVersion.WithKind("InClusterIPPool").GroupKind(), pool.Name, field.ErrorList{
 				field.Invalid(field.NewPath("spec", "prefix"), pool.Spec.Prefix, err.Error()),
@@ -63,18 +64,19 @@ func (webhook *InClusterIPPool) Default(ctx context.Context, obj runtime.Object)
 
 		pool.Spec.Subnet = prefix.String()
 	} else {
-		prefix, err := netaddr.ParseIPPrefix(pool.Spec.Subnet)
+		prefix, err := netip.ParsePrefix(pool.Spec.Subnet)
 		if err != nil {
 			return apierrors.NewInvalid(v1alpha1.GroupVersion.WithKind("InClusterIPPool").GroupKind(), pool.Name, field.ErrorList{
 				field.Invalid(field.NewPath("spec", "subnet"), pool.Spec.Subnet, err.Error()),
 			})
 		}
 
+		prefixRange := netipx.RangeOfPrefix(prefix)
 		if pool.Spec.First == "" {
-			pool.Spec.First = prefix.Range().From().Next().String() // omits the first address, the assumed gateway
+			pool.Spec.First = prefixRange.From().Next().String() // omits the first address, the assumed gateway
 		}
 		if pool.Spec.Last == "" {
-			pool.Spec.Last = prefix.Range().To().Prior().String() // omits the last address, the assumed broadcast
+			pool.Spec.Last = prefixRange.To().Prev().String() // omits the last address, the assumed broadcast
 		}
 		if pool.Spec.Prefix == 0 {
 			pool.Spec.Prefix = int(prefix.Bits())
@@ -124,32 +126,32 @@ func (webhook *InClusterIPPool) validate(_, newPool *v1alpha1.InClusterIPPool) (
 		return
 	}
 
-	prefix, err := netaddr.ParseIPPrefix(newPool.Spec.Subnet)
+	prefix, err := netip.ParsePrefix(newPool.Spec.Subnet)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "subnet"), newPool.Spec.Subnet, err.Error()))
 		return
 	}
 
-	first, err := netaddr.ParseIP(newPool.Spec.First)
+	first, err := netip.ParseAddr(newPool.Spec.First)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "first"), newPool.Spec.First, err.Error()))
 	} else if !prefix.Contains(first) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "first"), newPool.Spec.First, "address is not part of spec.subnet"))
 	}
 
-	last, err := netaddr.ParseIP(newPool.Spec.Last)
+	last, err := netip.ParseAddr(newPool.Spec.Last)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "last"), newPool.Spec.Last, err.Error()))
 	} else if !prefix.Contains(last) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "last"), newPool.Spec.Last, "address is not part of spec.subnet"))
 	}
 
-	if prefix.Bits() != uint8(newPool.Spec.Prefix) {
+	if prefix.Bits() != newPool.Spec.Prefix {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "prefix"), newPool.Spec.Prefix, "does not match prefix of spec.subnet"))
 	}
 
 	if newPool.Spec.Gateway != "" {
-		_, err := netaddr.ParseIP(newPool.Spec.Gateway)
+		_, err := netip.ParseAddr(newPool.Spec.Gateway)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "gateway"), newPool.Spec.Gateway, err.Error()))
 		}
@@ -178,7 +180,7 @@ func validateAddresses(newPool *v1alpha1.InClusterIPPool) field.ErrorList {
 	}
 
 	if newPool.Spec.Gateway != "" {
-		_, err := netaddr.ParseIP(newPool.Spec.Gateway)
+		_, err := netip.ParseAddr(newPool.Spec.Gateway)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "gateway"), newPool.Spec.Gateway, err.Error()))
 		}
@@ -201,31 +203,31 @@ func validateAddresses(newPool *v1alpha1.InClusterIPPool) field.ErrorList {
 	return allErrs
 }
 
-func validatePrefix(spec v1alpha1.InClusterIPPoolSpec) (*netaddr.IPSet, field.ErrorList) {
+func validatePrefix(spec v1alpha1.InClusterIPPoolSpec) (*netipx.IPSet, field.ErrorList) {
 	var errors field.ErrorList
 
 	addressesIPSet, err := poolutil.AddressesToIPSet(spec.Addresses)
 	if err != nil {
 		// this should not occur, previous validation should have caught problems here.
 		errors := append(errors, field.Invalid(field.NewPath("spec", "addresses"), spec.Addresses, err.Error()))
-		return &netaddr.IPSet{}, errors
+		return &netipx.IPSet{}, errors
 	}
 
 	firstIPInAddresses := addressesIPSet.Ranges()[0].From() // safe because of prior validation
-	prefix, err := netaddr.ParseIPPrefix(fmt.Sprintf("%s/%d", firstIPInAddresses, spec.Prefix))
+	prefix, err := netip.ParsePrefix(fmt.Sprintf("%s/%d", firstIPInAddresses, spec.Prefix))
 	if err != nil {
 		errors = append(errors, field.Invalid(field.NewPath("spec", "prefix"), spec.Prefix, "provided prefix is not valid"))
-		return &netaddr.IPSet{}, errors
+		return &netipx.IPSet{}, errors
 	}
 
-	builder := netaddr.IPSetBuilder{}
+	builder := netipx.IPSetBuilder{}
 	builder.AddPrefix(prefix)
 	prefixIPSet, err := builder.IPSet()
 	if err != nil {
 		// This should not occur, the prefix has been validated. Converting the prefix to an IPSet
 		// for it's ContainsRange function.
 		errors := append(errors, field.Invalid(field.NewPath("spec", "prefix"), spec.Prefix, err.Error()))
-		return &netaddr.IPSet{}, errors
+		return &netipx.IPSet{}, errors
 	}
 
 	return prefixIPSet, errors

--- a/internal/webhooks/inclusterippool_test.go
+++ b/internal/webhooks/inclusterippool_test.go
@@ -131,7 +131,7 @@ func TestInvalidScenarios(t *testing.T) {
 				Prefix:  24,
 				Gateway: "invalid",
 			},
-			expectedError: "spec.gateway: Invalid value: \"invalid\": ParseIP(\"invalid\"): unable to parse IP",
+			expectedError: "spec.gateway: Invalid value: \"invalid\": ParseAddr(\"invalid\"): unable to parse IP",
 		},
 		{
 			testcase: "specifying an address that belongs to separate subnets should not be allowed",


### PR DESCRIPTION
Replaces `inet.af/netaddr` with `net/netip` and `go4.org/netipx` since it is deprecated and does not build with go 1.20.

`netipx` contains everything fro `netaddr` that didn't make it into `net/netip` and is compatible with its types.