### PR TITLE
add explicit securityContexts to the controller

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,8 +31,6 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
-        securityContext:
-          allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
             path: /healthz
@@ -54,5 +52,16 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsUser: 65532
+          runAsGroup: 65532
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
**What this PR does / why we need it**:

This does not really change the configuration, it just makes it explicit and enforce the defaults, except for the seccompPolicy which changes from Unconfined to RuntimeDefault. Syscalls filtered by RuntimeDefault policy are 95% namespaced and require capabilities (which we drop) in the first place, so no practical change there either.

This allows to be compatible to the restricted pod security admission profile.

This is a recommendation in the [CAPI v1.3->1.4 upgrade guide](https://main.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.3-to-v1.4.html#suggested-changes-for-providers).

**Special notes for your reviewer**:

Prior art:
* https://github.com/kubernetes-sigs/cluster-api/pull/7831
* https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4104

Note: this requires the v1.4 branch of CAPI for usage with tilt, because the Tiltfile then removes the securityContext for allowing it to succeed.
