### PR TITLE
Add validation for IP family and gateways

### DIFF
--- a/internal/webhooks/inclusterippool_test.go
+++ b/internal/webhooks/inclusterippool_test.go
@@ -67,6 +67,65 @@ func TestInClusterIPPoolDefaulting(t *testing.T) {
 				Prefix:  28,
 			},
 		},
+		{
+			name: "addresses with prefix and no gateway",
+			spec: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"10.0.0.25",
+					"10.0.0.26",
+					"10.0.0.27",
+				},
+				Prefix: 28,
+			},
+			expect: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"10.0.0.25",
+					"10.0.0.26",
+					"10.0.0.27",
+				},
+				Prefix: 28,
+			},
+		},
+		{
+			name: "IPv6 addresses with gateway and prefix",
+			spec: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"fe01::2",
+					"fe01::3-fe01::5",
+					"fe01::1:1/126",
+				},
+				Gateway: "fe01::1",
+				Prefix:  28,
+			},
+			expect: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"fe01::2",
+					"fe01::3-fe01::5",
+					"fe01::1:1/126",
+				},
+				Gateway: "fe01::1",
+				Prefix:  28,
+			},
+		},
+		{
+			name: "IPv6 addresses and prefix with no gateway",
+			spec: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"fe01::2",
+					"fe01::3-fe01::5",
+					"fe01::1:1/126",
+				},
+				Prefix: 28,
+			},
+			expect: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"fe01::2",
+					"fe01::3-fe01::5",
+					"fe01::1:1/126",
+				},
+				Prefix: 28,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -307,6 +366,44 @@ func TestInvalidScenarios(t *testing.T) {
 				Gateway: "10.0.0.1",
 			},
 			expectedError: "provided address belongs to a different subnet than others",
+		},
+		{
+			testcase: "Addresses are IPv4 and Gateway is IPv6",
+			spec: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"10.0.1.0",
+					"10.0.0.2-10.0.0.250",
+				},
+				Prefix:  24,
+				Gateway: "fd00::1",
+			},
+			expectedError: "provided gateway and addresses are of mixed IP families",
+		},
+		{
+			testcase: "Addresses are IPv6 and Gateway is IPv4",
+			spec: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"fd00::1",
+					"fd00::100-fd00::200",
+				},
+				Prefix:  24,
+				Gateway: "10.0.0.1",
+			},
+			expectedError: "provided gateway and addresses are of mixed IP families",
+		},
+		{
+			testcase: "Addresses is using mismatched IP families",
+			spec: v1alpha1.InClusterIPPoolSpec{
+				Addresses: []string{
+					"fd00::1",
+					"fd00::100-fd00::200",
+					"10.0.1.0",
+					"10.0.0.2-10.0.0.250",
+				},
+				Prefix:  24,
+				Gateway: "10.0.0.1",
+			},
+			expectedError: "provided addresses are of mixed IP families",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- require IPv4 Gateway if addresses are IPv4
- continue to not require IPv6 Gateway if addresses are IPv6
- validate addresses are of the same family i.e cannot mix IPv4 and IPv6 addresses in a single pool
- validate addresses and gateway are of the same family (if gateway is provided)

Relates to #70

We did some experimenting around cases with and without Gateway. We think this PR represents common understandings and preferences. This PR puts forth that Gateway should be required with pools/addresses that are IPv4, and Gateway should be optional when addresses are IPv6. We're open to feedback if these choices seem incorrect or too heavy handed.

We see that (at least in our envs) that we are able to launch IPv6 machines without configuring a Gateway. The default route is provided by Router Advertisements. This leads us to the conclusion that there are valid cases when using IPv6 that Gateway should not be required.

Asides:
We intend to PR CAPI so that Gateway is optional when the IPAddress contains an IPv6 address. We intend to PR CAPI so that it requires Gateway when the address is IPv4.

We intend to PR CAPV so that Gateway is optional when the IPAddress is IPv6.