### PR TITLE
protect pools with IP allocations from deletion

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -77,6 +77,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - inclusterippools
   sideEffects: None
@@ -99,6 +100,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - globalinclusterippools
   sideEffects: None

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=

--- a/internal/controllers/inclusterippool.go
+++ b/internal/controllers/inclusterippool.go
@@ -198,7 +198,6 @@ func genericReconcile(ctx context.Context, c client.Client, pool pooltypes.Gener
 		}
 	}
 
-	inUseCount := len(addressesInUse)
 	free := poolCount - inUseCount
 
 	pool.PoolStatus().Addresses = &v1alpha1.InClusterIPPoolStatusIPAddresses{

--- a/internal/controllers/inclusterippool.go
+++ b/internal/controllers/inclusterippool.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -27,6 +28,9 @@ import (
 const (
 	inClusterIPPoolKind       = "InClusterIPPool"
 	globalInClusterIPPoolKind = "GlobalInClusterIPPool"
+
+	// ProtectPoolFinalizer is used to prevent deletion of a Pool object while its addresses have not been deleted.
+	ProtectPoolFinalizer = "ipam.cluster.x-k8s.io/ProtectPool"
 )
 
 // InClusterIPPoolReconciler reconciles a InClusterIPPool object.
@@ -162,6 +166,19 @@ func genericReconcile(ctx context.Context, c client.Client, pool pooltypes.Gener
 	addressesInUse, err := poolutil.ListAddressesInUse(ctx, c, pool.GetNamespace(), poolTypeRef)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to list addresses")
+	}
+
+	inUseCount := len(addressesInUse)
+
+	if !controllerutil.ContainsFinalizer(pool, ProtectPoolFinalizer) {
+		controllerutil.AddFinalizer(pool, ProtectPoolFinalizer)
+	}
+
+	if !pool.GetDeletionTimestamp().IsZero() {
+		if inUseCount == 0 {
+			controllerutil.RemoveFinalizer(pool, ProtectPoolFinalizer)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	poolIPSet, err := poolutil.IPPoolSpecToIPSet(pool.PoolSpec())

--- a/internal/controllers/inclusterippool_test.go
+++ b/internal/controllers/inclusterippool_test.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	clusterv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
+	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
@@ -41,27 +41,7 @@ var _ = Describe("IP Pool Reconciler", func() {
 
 		DescribeTable("it shows the total, used, free ip addresses in the pool",
 			func(poolType string, addresses []string, gateway string, expectedTotal, expectedUsed, expectedFree int) {
-				poolSpec := v1alpha1.InClusterIPPoolSpec{
-					Prefix:    24,
-					Gateway:   gateway,
-					Addresses: addresses,
-				}
-
-				switch poolType {
-				case "InClusterIPPool":
-					genericPool = &v1alpha1.InClusterIPPool{
-						ObjectMeta: metav1.ObjectMeta{GenerateName: testPool, Namespace: namespace},
-						Spec:       poolSpec,
-					}
-				case "GlobalInClusterIPPool":
-					genericPool = &v1alpha1.GlobalInClusterIPPool{
-						ObjectMeta: metav1.ObjectMeta{GenerateName: testPool, Namespace: namespace},
-						Spec:       poolSpec,
-					}
-				default:
-					Fail("Unknown pool type")
-				}
-
+				genericPool = newPool(poolType, testPool, namespace, gateway, addresses, 24)
 				Expect(k8sClient.Create(context.Background(), genericPool)).To(Succeed())
 
 				Eventually(Object(genericPool)).
@@ -72,12 +52,12 @@ var _ = Describe("IP Pool Reconciler", func() {
 				Expect(genericPool.PoolStatus().Addresses.Free).To(Equal(expectedTotal))
 
 				for i := 0; i < expectedUsed; i++ {
-					claim := clusterv1.IPAddressClaim{
+					claim := ipamv1.IPAddressClaim{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      fmt.Sprintf("test%d", i),
 							Namespace: namespace,
 						},
-						Spec: clusterv1.IPAddressClaimSpec{
+						Spec: ipamv1.IPAddressClaimSpec{
 							PoolRef: corev1.TypedLocalObjectReference{
 								APIGroup: pointer.String("ipam.cluster.x-k8s.io"),
 								Kind:     poolType,
@@ -120,4 +100,77 @@ var _ = Describe("IP Pool Reconciler", func() {
 				"GlobalInClusterIPPool", []string{"10.0.0.10-10.0.0.20"}, "10.0.0.1", 11, 1, 10),
 		)
 	})
+
+	Context("when the pool has IPAddresses", func() {
+		const poolName = "finalizer-pool-test"
+
+		DescribeTable("add a finalizer to prevent pool deletion before IPAddresses are deleted", func(poolType string) {
+			pool := newPool(poolType, poolName, namespace, "10.0.1.2", []string{"10.0.1.1-10.0.1.254"}, 24)
+			Expect(k8sClient.Create(context.Background(), pool)).To(Succeed())
+			Eventually(Get(pool)).Should(Succeed())
+
+			claim := ipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "finalizer-pool-test",
+					Namespace: namespace,
+				},
+				Spec: ipamv1.IPAddressClaimSpec{
+					PoolRef: corev1.TypedLocalObjectReference{
+						APIGroup: pointer.String("ipam.cluster.x-k8s.io"),
+						Kind:     poolType,
+						Name:     pool.GetName(),
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(context.Background(), &claim)).To(Succeed())
+
+			addresses := ipamv1.IPAddressList{}
+			Eventually(ObjectList(&addresses)).
+				WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).Should(
+				HaveField("Items", HaveLen(1)))
+
+			Eventually(Object(pool)).
+				WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).Should(
+				HaveField("ObjectMeta.Finalizers", ContainElement(ProtectPoolFinalizer)))
+
+			Expect(k8sClient.Delete(context.Background(), pool)).To(Succeed())
+
+			Consistently(Object(pool)).
+				WithTimeout(5 * time.Second).WithPolling(100 * time.Millisecond).Should(
+				HaveField("ObjectMeta.Finalizers", ContainElement(ProtectPoolFinalizer)))
+
+			deleteClaim("finalizer-pool-test", namespace)
+
+			Eventually(Get(pool)).Should(Not(Succeed()))
+		},
+			Entry("validates InClusterIPPool", "InClusterIPPool"),
+			Entry("validates GlobalInClusterIPPool", "GlobalInClusterIPPool"),
+		)
+	})
 })
+
+func newPool(poolType, generateName, namespace, gateway string, addresses []string, prefix int) pooltypes.GenericInClusterPool {
+	poolSpec := v1alpha1.InClusterIPPoolSpec{
+		Prefix:    prefix,
+		Gateway:   gateway,
+		Addresses: addresses,
+	}
+
+	switch poolType {
+	case "InClusterIPPool":
+		return &v1alpha1.InClusterIPPool{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: generateName, Namespace: namespace},
+			Spec:       poolSpec,
+		}
+	case "GlobalInClusterIPPool":
+		return &v1alpha1.GlobalInClusterIPPool{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: generateName},
+			Spec:       poolSpec,
+		}
+	default:
+		Fail("Unknown pool type")
+	}
+
+	return nil
+}

--- a/internal/controllers/ipaddressclaim_test.go
+++ b/internal/controllers/ipaddressclaim_test.go
@@ -679,7 +679,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 		})
 
 		When("there are two pools with the same name in different namespaces", func() {
-			const commonPoolName = "comomon-pool-name"
+			const commonPoolName = "common-pool-name"
 			var secondNamespace string
 			var claim1, claim2 ipamv1.IPAddressClaim
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -23,7 +23,7 @@ const (
 func SetupIndexes(ctx context.Context, mgr manager.Manager) error {
 	err := mgr.GetCache().IndexField(ctx, &ipamv1.IPAddress{},
 		IPAddressPoolRefCombinedField,
-		ipAddressByCombinedPoolRef,
+		IPAddressByCombinedPoolRef,
 	)
 	if err != nil {
 		return err
@@ -35,7 +35,8 @@ func SetupIndexes(ctx context.Context, mgr manager.Manager) error {
 	)
 }
 
-func ipAddressByCombinedPoolRef(o client.Object) []string {
+// IPAddressByCombinedPoolRef fulfills the IndexerFunc for IPAddress poolRefs.
+func IPAddressByCombinedPoolRef(o client.Object) []string {
 	ip, ok := o.(*ipamv1.IPAddress)
 	if !ok {
 		panic(fmt.Sprintf("Expected an IPAddress but got a %T", o))

--- a/internal/poolutil/pool.go
+++ b/internal/poolutil/pool.go
@@ -21,7 +21,7 @@ import (
 
 // ListAddressesInUse fetches all IPAddresses belonging to the specified pool.
 // Note: requires `index.ipAddressByCombinedPoolRef` to be set up.
-func ListAddressesInUse(ctx context.Context, c client.Client, namespace string, poolRef corev1.TypedLocalObjectReference) ([]ipamv1.IPAddress, error) {
+func ListAddressesInUse(ctx context.Context, c client.Reader, namespace string, poolRef corev1.TypedLocalObjectReference) ([]ipamv1.IPAddress, error) {
 	addresses := &ipamv1.IPAddressList{}
 	err := c.List(ctx, addresses,
 		client.MatchingFields{

--- a/internal/webhooks/util_test.go
+++ b/internal/webhooks/util_test.go
@@ -44,7 +44,7 @@ func customDefaultValidateTest(ctx context.Context, obj runtime.Object, webhook 
 			g := gomega.NewWithT(t)
 			deleteCopy := obj.DeepCopyObject()
 			g.Expect(webhook.Default(ctx, deleteCopy)).To(gomega.Succeed())
-			g.Expect(webhook.ValidateDelete(ctx, deleteCopy)).To(gomega.Succeed())
+			g.Expect(webhook.ValidateDelete(ctx, deleteCopy)).To(gomega.Succeed(), "should pass validation")
 		})
 	}
 }


### PR DESCRIPTION
Adds a finalizer to prevent pool deletion when IPs are still allocated

Adds a delete webhook check that will ensure pools with allocated IPs cannot be removed

This change relies on work in #116, when that is merged we can rebase this.

Fixes #114 