### PR TITLE
Webhook Validate updated pool does not remove in use IPs

### DIFF
--- a/api/v1alpha1/inclusterippool_types.go
+++ b/api/v1alpha1/inclusterippool_types.go
@@ -59,6 +59,11 @@ type InClusterIPPoolStatusIPAddresses struct {
 	// Used is the count of allocated IPs in the pool.
 	// Counts greater than int can contain will report as math.MaxInt.
 	Used int `json:"used"`
+
+	// Out of Range is the count of allocated IPs in the pool that is not
+	// contained within spec.Addresses.
+	// Counts greater than int can contain will report as math.MaxInt.
+	OutOfRange int `json:"outOfRange"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
@@ -103,6 +103,11 @@ spec:
                     description: Free is the count of unallocated IPs in the pool.
                       Counts greater than int can contain will report as math.MaxInt.
                     type: integer
+                  outOfRange:
+                    description: Out of Range is the count of allocated IPs in the
+                      pool that is not contained within spec.Addresses. Counts greater
+                      than int can contain will report as math.MaxInt.
+                    type: integer
                   total:
                     description: Total is the total number of IPs configured for the
                       pool. Counts greater than int can contain will report as math.MaxInt.
@@ -113,6 +118,7 @@ spec:
                     type: integer
                 required:
                 - free
+                - outOfRange
                 - total
                 - used
                 type: object

--- a/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
@@ -105,6 +105,11 @@ spec:
                     description: Free is the count of unallocated IPs in the pool.
                       Counts greater than int can contain will report as math.MaxInt.
                     type: integer
+                  outOfRange:
+                    description: Out of Range is the count of allocated IPs in the
+                      pool that is not contained within spec.Addresses. Counts greater
+                      than int can contain will report as math.MaxInt.
+                    type: integer
                   total:
                     description: Total is the total number of IPs configured for the
                       pool. Counts greater than int can contain will report as math.MaxInt.
@@ -115,6 +120,7 @@ spec:
                     type: integer
                 required:
                 - free
+                - outOfRange
                 - total
                 - used
                 type: object

--- a/internal/controllers/inclusterippool.go
+++ b/internal/controllers/inclusterippool.go
@@ -199,11 +199,16 @@ func genericReconcile(ctx context.Context, c client.Client, pool pooltypes.Gener
 	}
 
 	free := poolCount - inUseCount
+	outOfRangeIPSet, err := poolutil.AddressesOutOfRangeIPSet(addressesInUse, poolIPSet)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to build out of range ip set")
+	}
 
 	pool.PoolStatus().Addresses = &v1alpha1.InClusterIPPoolStatusIPAddresses{
-		Total: poolCount,
-		Used:  inUseCount,
-		Free:  free,
+		Total:      poolCount,
+		Used:       inUseCount,
+		Free:       free,
+		OutOfRange: poolutil.IPSetCount(outOfRangeIPSet),
 	}
 
 	log.Info("Updating pool with usage info", "statusAddresses", pool.PoolStatus().Addresses)

--- a/internal/webhooks/inclusterippool.go
+++ b/internal/webhooks/inclusterippool.go
@@ -154,7 +154,7 @@ func (webhook *InClusterIPPool) ValidateUpdate(ctx context.Context, oldObj, newO
 	inUseBuilder.RemoveSet(newPoolIPSet)
 	outOfRangeIPSet, err := inUseBuilder.IPSet()
 	if err != nil {
-		panic("oh no")
+		return apierrors.NewInternalError(err)
 	}
 
 	if outOfRange := outOfRangeIPSet.Ranges(); len(outOfRange) > 0 {

--- a/internal/webhooks/inclusterippool.go
+++ b/internal/webhooks/inclusterippool.go
@@ -110,7 +110,7 @@ func (webhook *InClusterIPPool) ValidateCreate(_ context.Context, obj runtime.Ob
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (webhook *InClusterIPPool) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
+func (webhook *InClusterIPPool) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
 	newPool, ok := newObj.(types.GenericInClusterPool)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a InClusterIPPool or an GlobalInClusterIPPool but got a %T", newObj))
@@ -119,7 +119,49 @@ func (webhook *InClusterIPPool) ValidateUpdate(_ context.Context, oldObj, newObj
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a InClusterIPPool or an GlobalInClusterIPPool but got a %T", oldObj))
 	}
-	return webhook.validate(oldPool, newPool)
+
+	err := webhook.validate(oldPool, newPool)
+	if err != nil {
+		return err
+	}
+
+	oldPoolRef := corev1.TypedLocalObjectReference{
+		APIGroup: pointer.String(v1alpha1.GroupVersion.Group),
+		Kind:     oldPool.GetObjectKind().GroupVersionKind().Kind,
+		Name:     oldPool.GetName(),
+	}
+	inUseAddresses, err := poolutil.ListAddressesInUse(ctx, webhook.Client, oldPool.GetNamespace(), oldPoolRef)
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
+	inUseBuilder := &netipx.IPSetBuilder{}
+	for _, address := range inUseAddresses {
+		ip, err := netip.ParseAddr(address.Spec.Address)
+		if err != nil {
+			// if an address we fetch for the pool is unparsable then it isn't in the pool ranges
+			continue
+		}
+		inUseBuilder.Add(ip)
+	}
+
+	newPoolIPSet, err := poolutil.AddressesToIPSet(newPool.PoolSpec().Addresses)
+	if err != nil {
+		// these addresses are already validated, this shouldn't happen
+		return apierrors.NewInternalError(err)
+	}
+
+	inUseBuilder.RemoveSet(newPoolIPSet)
+	outOfRangeIPSet, err := inUseBuilder.IPSet()
+	if err != nil {
+		panic("oh no")
+	}
+
+	if outOfRange := outOfRangeIPSet.Ranges(); len(outOfRange) > 0 {
+		return apierrors.NewBadRequest(fmt.Sprintf("pool addresses does not contain allocated addresses: %v", outOfRange))
+	}
+
+	return nil
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.


### PR DESCRIPTION
In the case that the a pool is still updated and has out of range IPs display the count in the pool status

Relies on #116, we can update this when that is merged

Fixes #117, with the exception of `In addition to the outOfRange status count on the pool we could also add an outOfRange status condition on the IPAddress.`

This last bit would require changes to the IPAddress resource in core CAPI. The Status field is missing on the IPAddress objects. We think this is okay for now and we can open a new issue for that if we still think it is valuable.