### PR TITLE
Add necessary kubernetes template files for kubernetes-sigs move

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing Guidelines
+
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://git.k8s.io/community)! The Kubernetes community abides by the CNCF [code of conduct](code-of-conduct.md). Here is an excerpt:
+
+_As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
+
+## Getting Started
+
+We have full documentation on how to get started contributing here:
+
+<!---
+If your repo has certain guidelines for contribution, put them here ahead of the general k8s resources
+-->
+
+- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) - Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
+- [Kubernetes Contributor Guide](https://k8s.dev/guide) - Main contributor documentation, or you can just jump directly to the [contributing page](https://k8s.dev/docs/guide/contributing/)
+- [Contributor Cheat Sheet](https://k8s.dev/cheatsheet) - Common resources for existing developers
+
+
+## Contributing a patch
+
+1. Submit an issue describing your proposed change to the repo in question.
+2. The repo owners will respond to your issue promptly.
+3. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
+4. Fork the desired repo, develop and test your code changes.
+5. Submit a pull request.
+
+
+## Mentorship
+
+- [Mentoring Initiatives](https://k8s.dev/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!
+
+<!---
+Custom Information - if you're copying this template for the first time you can add custom content here, for example:
+
+## Contact Information
+
+- [Slack channel](https://kubernetes.slack.com/messages/kubernetes-users) - Replace `kubernetes-users` with your slack channel string, this will send users directly to your channel.
+- [Mailing list](URL)
+-->

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners for information on OWNERS files.
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/cluster-api/blob/main/OWNERS_ALIASES for a list of members for each alias.
+
+approvers:
+  - cluster-api-ipam-provider-in-cluster-maintainers
+
+reviewers:
+  - cluster-api-ipam-provider-in-cluster-maintainers
+  - cluster-api-ipam-provider-in-cluster-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
+
+aliases:
+  cluster-api-ipam-provider-in-cluster-maintainers:
+    - schrej
+
+  cluster-api-ipam-provider-in-cluster-reviewers:
+    - schrej

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ spec:
   gateway: 10.0.0.1
 ```
 
+## Community, discussion, contribution, and support
+
+Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
+
+You can reach the maintainers of this project at:
+
+- [Slack](https://slack.k8s.io/)
+- [Mailing List](https://groups.google.com/a/kubernetes.io/g/dev)
+
 ## Licensing
 
 Copyright (c) 2022 Deutsche Telekom AG.

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,13 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Security Response Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+schrej


### PR DESCRIPTION
This PR adds the necessary template files from https://github.com/kubernetes/kubernetes-template-project for the move to kubernetes-sigs.

There are probably a few areas that can be fleshed out more that haven't been yet. Here are some things in no particular order:

* For the contributing.md it was left fairly vanilla from the template file, except I added a contributing a patch section taken from the cluster-api-provider-vsphere contributing.md.
* For the Owners Alias, it currently only has @schrej, but we could add some/all of the VMware based contributors we have on our team (@tylerschultz @adobley @flawedmatrix and @christianang). Wasn't sure if it was better to do it before or after the move so I left it as is. Same with the Security Contacts file.
* For the readme II added the `Community, discussion, contribution, and support` section, but it doesn't link to any specific cluster-api-ipam-provider-in-cluster specific slack or mailing list yet. Not sure what the process there is, but maybe that can be figured out later?

Relates to #110 