### PR TITLE
:bug: Add skip validate delete webhook annotation

### DIFF
--- a/internal/webhooks/inclusterippool.go
+++ b/internal/webhooks/inclusterippool.go
@@ -20,6 +20,13 @@ import (
 	"github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/types"
 )
 
+const (
+	// SkipValidateDeleteWebhookAnnotation is an annotation that can be applied
+	// to the InClusterIPPool or GlobalInClusterIPPool to skip delete
+	// validation. Necessary for clusterctl move to work as expected.
+	SkipValidateDeleteWebhookAnnotation = "ipam.cluster.x-k8s.io/skip-validate-delete-webhook"
+)
+
 func (webhook *InClusterIPPool) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	err := ctrl.NewWebhookManagedBy(mgr).
 		For(&v1alpha1.InClusterIPPool{}).
@@ -127,6 +134,10 @@ func (webhook *InClusterIPPool) ValidateDelete(ctx context.Context, obj runtime.
 	pool, ok := obj.(types.GenericInClusterPool)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a InClusterIPPool or an GlobalInClusterIPPool but got a %T", obj))
+	}
+
+	if _, ok := pool.GetAnnotations()[SkipValidateDeleteWebhookAnnotation]; ok {
+		return nil
 	}
 
 	poolTypeRef := corev1.TypedLocalObjectReference{

--- a/internal/webhooks/inclusterippool_test.go
+++ b/internal/webhooks/inclusterippool_test.go
@@ -100,6 +100,89 @@ func TestPoolDeletionWithExistingIPAddresses(t *testing.T) {
 	g.Expect(webhook.ValidateDelete(ctx, globalPool)).To(Succeed(), "should allow deletion when no claims exist")
 }
 
+func TestDeleteSkip(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(ipamv1.AddToScheme(scheme)).To(Succeed())
+
+	namespacedPool := &v1alpha1.InClusterIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-pool",
+			Annotations: map[string]string{
+				SkipValidateDeleteWebhookAnnotation: "",
+			},
+		},
+		Spec: v1alpha1.InClusterIPPoolSpec{
+			Addresses: []string{"10.0.0.10-10.0.0.20"},
+			Prefix:    24,
+			Gateway:   "10.0.0.1",
+		},
+	}
+
+	globalPool := &v1alpha1.InClusterIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-pool",
+			Annotations: map[string]string{
+				SkipValidateDeleteWebhookAnnotation: "",
+			},
+		},
+		Spec: v1alpha1.InClusterIPPoolSpec{
+			Addresses: []string{"10.0.0.10-10.0.0.20"},
+			Prefix:    24,
+			Gateway:   "10.0.0.1",
+		},
+	}
+
+	ips := []client.Object{
+		&ipamv1.IPAddress{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "IPAddress",
+				APIVersion: "ipam.cluster.x-k8s.io/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-ip",
+			},
+			Spec: ipamv1.IPAddressSpec{
+				PoolRef: corev1.TypedLocalObjectReference{
+					APIGroup: pointer.String(namespacedPool.GetObjectKind().GroupVersionKind().Group),
+					Kind:     namespacedPool.GetObjectKind().GroupVersionKind().Kind,
+					Name:     namespacedPool.GetName(),
+				},
+			},
+		},
+		&ipamv1.IPAddress{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "IPAddress",
+				APIVersion: "ipam.cluster.x-k8s.io/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-ip-2",
+			},
+			Spec: ipamv1.IPAddressSpec{
+				PoolRef: corev1.TypedLocalObjectReference{
+					APIGroup: pointer.String(globalPool.GetObjectKind().GroupVersionKind().Group),
+					Kind:     globalPool.GetObjectKind().GroupVersionKind().Kind,
+					Name:     globalPool.GetName(),
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ips...).
+		WithIndex(&ipamv1.IPAddress{}, index.IPAddressPoolRefCombinedField, index.IPAddressByCombinedPoolRef).
+		Build()
+
+	webhook := InClusterIPPool{
+		Client: fakeClient,
+	}
+
+	g.Expect(webhook.ValidateDelete(ctx, namespacedPool)).To(Succeed())
+	g.Expect(webhook.ValidateDelete(ctx, globalPool)).To(Succeed())
+}
+
 func TestInClusterIPPoolDefaulting(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION


<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds a `ipam.cluster.x-k8s.io/skip-validate-delete-webhook` annotation that can be added to pools to skip delete validation. This is necessary for clusterctl move to work because it attempts to delete everything off the source cluster and it cannot control the order of deletion so it may delete pools before ipaddressclaims.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #140
